### PR TITLE
typo/ grammar fix

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,7 +9,7 @@ import streamlit as st
 
 Edit `/streamlit_app.py` to customize this app to your heart's desire :heart:
 
-If you have any questions, checkout our [documentation](https://docs.streamlit.io) and [community
+If you have any questions, check out our [documentation](https://docs.streamlit.io) and [community
 forums](https://discuss.streamlit.io).
 
 In the meantime, below is an example of what you can do with just a few lines of code:


### PR DESCRIPTION
checkout vs check out. Info [here](https://www.grammarphobia.com/blog/2019/05/checkout.html#:~:text=The%20phrasal%20verb%20is%20%E2%80%9Ccheck,%E2%80%9Ccheckout%2C%E2%80%9D%20one%20word.&text=If%20the%20adjective%20is%20intended,short%20for%20%E2%80%9CCheckout%20Option.%E2%80%9D)